### PR TITLE
fix: remove header elements to revert to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,14 +6,12 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chatbot</title>
     <link rel="stylesheet" href="style.css?v=10">
 </head>
 <body>
     <div class="container">
         <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
             <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Switch between light and dark themes">
                 <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -68,30 +68,14 @@ body {
 /* Header - Visible with Theme Toggle */
 header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     padding: 1rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
-    transition: background-color 0.3s ease, border-color 0.3s ease;
+    transition: background-color 0.3s ease;
 }
 
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {


### PR DESCRIPTION
Fixes #2

Reverted the header to the older version by removing:
- "Course Materials Assistant" title
- "Ask questions about courses, instructors, and content" subtitle
- Horizontal line below header

Preserved theme toggle functionality in top-right corner.

Generated with [Claude Code](https://claude.ai/code)